### PR TITLE
Fix TapoCam PTZ log typo

### DIFF
--- a/unifi/cams/tapo.py
+++ b/unifi/cams/tapo.py
@@ -36,7 +36,7 @@ class TapoCam(UnifiCamBase):
             self.logger.info("PTZ Not enabled because of insufficient configuration")
 
         except Exception:
-            self.logger.info("PTZ Not enabled, not supportet for this camera")
+            self.logger.info("PTZ Not enabled, not supported for this camera")
 
         if not self.args.snapshot_url:
             self.start_snapshot_stream()


### PR DESCRIPTION
## Summary
- correct the PTZ fallback log message for Tapo cameras

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68439294aa80832e81a5d289e1a7b0d0