### PR TITLE
Enable manual PR preview

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -9,6 +9,12 @@ on:
     types:
         - opened
         - synchronize
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to preview
+        required: true
+        type: string
 
 jobs:
   # Single deploy job since we're just deploying
@@ -16,8 +22,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set PR number for manual run
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "pr_number=${{ github.event.inputs.pr_number }}" >> "$GITHUB_ENV"
+      - name: Set PR number from event
+        if: github.event_name == 'pull_request'
+        run: echo "pr_number=${{ github.event.pull_request.number }}" >> "$GITHUB_ENV"
       - name: Deploy PR Preview
         uses: rossjrw/pr-preview-action@v1.6.1
+        env:
+            pr_number: ${{ env.pr_number }}
         with:
             token: ${{ secrets.GITHUB_TOKEN }}
             preview-branch: gh-pages


### PR DESCRIPTION
## Summary
- allow triggering the preview workflow manually
- set PR number using workflow inputs for manual runs

## Testing
- `pre-commit run --files .github/workflows/preview.yml`

------
https://chatgpt.com/codex/tasks/task_e_6843a0f6ee58832eaef34406ffa22529