### PR TITLE
Fix ffmpeg help typo

### DIFF
--- a/unifi/cams/base.py
+++ b/unifi/cams/base.py
@@ -84,7 +84,7 @@ class UnifiCamBase(metaclass=ABCMeta):
         parser.add_argument(
             "--format",
             default="flv",
-            help="Set the ffpmeg output format",
+            help="Set the ffmpeg output format",
         )
 
     async def _run(self, ws) -> None:


### PR DESCRIPTION
## Summary
- fix a typo in the ffmpeg output format option description

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843c0ee7f7c832e9b8304a8dfa21d98