### PR TITLE
Add video codec option

### DIFF
--- a/unifi/cams/reolink.py
+++ b/unifi/cams/reolink.py
@@ -153,5 +153,5 @@ class Reolink(UnifiCamBase):
 
         return (
             f"rtsp://{self.args.username}:{self.args.password}@{self.args.ip}:554"
-            f"//h264Preview_{int(self.args.channel) + 1:02}_{stream}"
+            f"//{'h264Preview' if self.args.video_codec == 'h264' else 'h265Preview'}_{int(self.args.channel) + 1:02}_{stream}"
         )

--- a/unifi/cams/reolink_nvr.py
+++ b/unifi/cams/reolink_nvr.py
@@ -87,5 +87,5 @@ class ReolinkNVRCam(UnifiCamBase):
     async def get_stream_source(self, stream_index: str) -> str:
         return (
             f"rtsp://{self.args.username}:{self.args.password}@{self.args.ip}:554"
-            f"/h264Preview_{int(self.args.channel) + 1:02}_main"
+            f"/{'h264Preview' if self.args.video_codec == 'h264' else 'h265Preview'}_{int(self.args.channel) + 1:02}_main"
         )

--- a/unifi/cams/rtsp.py
+++ b/unifi/cams/rtsp.py
@@ -21,7 +21,8 @@ class RTSPCam(UnifiCamBase):
         for i, stream_index in enumerate(["video1", "video2", "video3"]):
             if not i < len(self.args.source):
                 i = -1
-            self.stream_source[stream_index] = self.args.source[i]
+            src = self.args.source[i].replace("{codec}", self.args.video_codec)
+            self.stream_source[stream_index] = src
         if not self.args.snapshot_url:
             self.start_snapshot_stream()
 
@@ -55,7 +56,7 @@ class RTSPCam(UnifiCamBase):
             cmd = (
                 f"AV_LOG_FORCE_NOCOLOR=1 ffmpeg -loglevel level+{self.args.loglevel} "
                 f"-nostdin -y -re -rtsp_transport {self.args.rtsp_transport} "
-                f'-i "{self.args.source[-1]}" '
+                f'-i "{self.args.source[-1].replace("{codec}", self.args.video_codec)}" '
                 "-r 1 "
                 f"-update 1 {self.snapshot_dir}/screen.jpg"
             )

--- a/unifi/main.py
+++ b/unifi/main.py
@@ -107,6 +107,12 @@ def parse_args():
     parser.add_argument(
         "--verbose", "-v", action="store_true", help="increase output verbosity"
     )
+    parser.add_argument(
+        "--video-codec",
+        default="h264",
+        choices=["h264", "h265"],
+        help="Video codec used for RTSP streams",
+    )
 
     sp = parser.add_subparsers(
         help="Camera implementations",


### PR DESCRIPTION
## Summary
- add global `--video-codec` arg
- support codec in RTSPCam stream sources
- allow Reolink cameras to pick h264/h265 streams

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a0c25348832e8bf6956493f225e4