### PR TITLE
Add H.265 streaming support

### DIFF
--- a/docs/docs/configuration/reolink.md
+++ b/docs/docs/configuration/reolink.md
@@ -14,7 +14,19 @@ unifi-cam-proxy -H {NVR IP} -i {camera IP} -c /client.pem -t {Adoption token} \
     -u {username} \
     -p {password} \
     -s "main" \
+    --video-codec h264 \
     --ffmpeg-args='-c:v copy -bsf:v "h264_metadata=tick_rate=60000/1001" -ar 32000 -ac 1 -codec:a aac -b:a 32k'
+
+# For cameras streaming H.265 use the following:
+
+```sh
+unifi-cam-proxy -H {NVR IP} -i {camera IP} -c /client.pem -t {Adoption token} \
+    reolink \
+    -u {username} \
+    -p {password} \
+    -s "main" \
+    --video-codec h265 \
+    --ffmpeg-args='-c:v copy -bsf:v "hevc_metadata=tick_rate=60000/1001" -ar 32000 -ac 1 -codec:a aac -b:a 32k'
 ```
 
 ## Options

--- a/unifi/cams/reolink.py
+++ b/unifi/cams/reolink.py
@@ -140,10 +140,12 @@ class Reolink(UnifiCamBase):
         else:
             fps = self.stream_fps[1]
 
-        return (
-            "-acodec copy -c:v copy -vbsf"
-            f' "h264_metadata=tick_rate={fps * 2}"'
-        )
+        if self.args.video_codec == "h265":
+            bsf = f'-bsf:v "hevc_metadata=tick_rate={fps * 2}"'
+        else:
+            bsf = f'-vbsf "h264_metadata=tick_rate={fps * 2}"'
+
+        return f"-acodec copy -c:v copy {bsf}"
 
     async def get_stream_source(self, stream_index: str) -> str:
         if stream_index == "video1":


### PR DESCRIPTION
## Summary
- add `--video-codec` option to camera base
- insert HEVC bitstream filter when using H.265
- support H.265 filters in Reolink implementation
- document H.265 usage for Reolink

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a0c4acd0832ea34260fd6c9321e6