### PR TITLE
Update camera configuration docs for h265

### DIFF
--- a/docs/docs/configuration/amcrest.md
+++ b/docs/docs/configuration/amcrest.md
@@ -26,6 +26,8 @@ optional arguments:
                         Sub Stream subtype index
   --motion-index MOTION_INDEX
                         VideoMotion event index
+  --video-codec {h264,h265}
+                        Select video codec for Protect streams
 ```
 
 ## Amcrest IP8M-T2599E
@@ -35,7 +37,7 @@ optional arguments:
 - [ ] Supports smart detection
 - Notes:
   - Camera configuration:
-    - Video codec must be H.264 (H.265/HEVC is not supported).
+    - Select `--video-codec h265` when adopting H.265/HEVC streams.
     - Audio codec should be AAC. If not, adjust the ffmpeg args to re-encode to AAC.
     - Ensure the sub stream is enabled.
     - If desired, ensure motion detection is enabled with the desired anti-dither and detection area.
@@ -51,4 +53,17 @@ unifi-cam-proxy --mac '{unique MAC}' -H {NVR IP} -i {camera IP} -c /client.pem -
     --motion-index 0 \
     --snapshot-channel 1 \
     --ffmpeg-args='-c:a copy -c:v copy -bsf:v "h264_metadata=tick_rate=30000/1001"'
+```
+
+### H.265 Example
+
+```sh
+unifi-cam-proxy --mac '{unique MAC}' -H {NVR IP} -i {camera IP} -c /client.pem -t {Adoption token} \
+    amcrest \
+    -u {username} \
+    -p {password} \
+    --motion-index 0 \
+    --snapshot-channel 1 \
+    --video-codec h265 \
+    --ffmpeg-args='-c:a copy -c:v copy'
 ```

--- a/docs/docs/configuration/dahua.md
+++ b/docs/docs/configuration/dahua.md
@@ -26,6 +26,8 @@ optional arguments:
                         Sub Stream subtype index
   --motion-index MOTION_INDEX
                         VideoMotion event index
+  --video-codec {h264,h265}
+                        Select video codec for Protect streams
 ```
 
 ## Lorex LNB4321B
@@ -39,5 +41,16 @@ unifi-cam-proxy --mac '{unique MAC}' -H {NVR IP} -i {camera IP} -c /client.pem -
     dahua \
     -u {username} \
     -p {password} \
+    --ffmpeg-args="-f lavfi -i anullsrc -c:v copy -ar 32000 -ac 1 -codec:a aac -b:a 32k"
+```
+
+### H.265 Example
+
+```sh
+unifi-cam-proxy --mac '{unique MAC}' -H {NVR IP} -i {camera IP} -c /client.pem -t {Adoption token} \
+    dahua \
+    -u {username} \
+    -p {password} \
+    --video-codec h265 \
     --ffmpeg-args="-f lavfi -i anullsrc -c:v copy -ar 32000 -ac 1 -codec:a aac -b:a 32k"
 ```

--- a/docs/docs/configuration/frigate.md
+++ b/docs/docs/configuration/frigate.md
@@ -20,6 +20,19 @@ unifi-cam-proxy --mac '{unique MAC}' -H {NVR IP} -i {camera IP} -c /client.pem -
     --frigate-camera {Name of camera in frigate}
 ```
 
+## H.265 Example
+
+```sh
+unifi-cam-proxy --mac '{unique MAC}' -H {NVR IP} -i {camera IP} -c /client.pem -t {Adoption token} \
+    frigate \
+    -s {rtsp source} \
+    --mqtt-host {mqtt host} \
+    --mqtt-username {mqtt username} \
+    --mqtt-password {mqtt password} \
+    --frigate-camera {Name of camera in frigate} \
+    --video-codec h265
+```
+
 ## Options
 
 ```text
@@ -45,4 +58,6 @@ optional arguments:
                         Topic prefix
   --frigate-camera FRIGATE_CAMERA
                         Name of camera in frigate
+  --video-codec {h264,h265}
+                        Select video codec for Protect streams
 ```

--- a/docs/docs/configuration/hikvision.md
+++ b/docs/docs/configuration/hikvision.md
@@ -24,6 +24,8 @@ optional arguments:
                         Camera username
   --password PASSWORD, -p PASSWORD
                         Camera password
+  --video-codec {h264,h265}
+                        Select video codec for Protect streams
 ```
 
 ## Hikvision DS-2DE3304W-DE
@@ -37,4 +39,12 @@ optional arguments:
 ```sh
 unifi-cam-proxy --mac '{unique MAC}' -H {NVR IP} -i {camera IP} -c /client.pem -t {Adoption token} \
     hikvision -u {username} -p {password}
+```
+
+### H.265 Example
+
+```sh
+unifi-cam-proxy --mac '{unique MAC}' -H {NVR IP} -i {camera IP} -c /client.pem -t {Adoption token} \
+    hikvision -u {username} -p {password} \
+    --video-codec h265
 ```

--- a/docs/docs/configuration/reolink.md
+++ b/docs/docs/configuration/reolink.md
@@ -17,6 +17,18 @@ unifi-cam-proxy -H {NVR IP} -i {camera IP} -c /client.pem -t {Adoption token} \
     --ffmpeg-args='-c:v copy -bsf:v "h264_metadata=tick_rate=60000/1001" -ar 32000 -ac 1 -codec:a aac -b:a 32k'
 ```
 
+### H.265 Example
+
+```sh
+unifi-cam-proxy -H {NVR IP} -i {camera IP} -c /client.pem -t {Adoption token} \
+    reolink \
+    -u {username} \
+    -p {password} \
+    -s "main" \
+    --video-codec h265 \
+    --ffmpeg-args='-c:v copy -ar 32000 -ac 1 -codec:a aac -b:a 32k'
+```
+
 ## Options
 
 ```text
@@ -32,7 +44,9 @@ optional arguments:
                         Camera password
   --substream SUBSTREAM, -s CHANNEL
                         Camera rtsp url substream index main, or sub
-```  
+  --video-codec {h264,h265}
+                        Select video codec for Protect streams
+```
 
 ## RLC-410-5MP
 

--- a/docs/docs/configuration/reolink_nvr.md
+++ b/docs/docs/configuration/reolink_nvr.md
@@ -19,7 +19,9 @@ optional arguments:
                         NVR password
   --channel CHANNEL, -c CHANNEL
                         NVR camera channel
-```  
+  --video-codec {h264,h265}
+                        Select video codec for Protect streams
+```
 
 ## NVR (Reolink RLN16-410)
 
@@ -35,4 +37,15 @@ unifi-cam-proxy --mac '{unique MAC}' -H {Protect IP} -i {Reolink NVR IP} -c /cli
     -u {username} \
     -p {password} \
     -c {Camera channel}
+```
+
+### H.265 Example
+
+```sh
+unifi-cam-proxy --mac '{unique MAC}' -H {Protect IP} -i {Reolink NVR IP} -c /client.pem -t {Adoption token} \
+    reolink_nvr \
+    -u {username} \
+    -p {password} \
+    -c {Camera channel} \
+    --video-codec h265
 ```

--- a/docs/docs/configuration/rtsp.md
+++ b/docs/docs/configuration/rtsp.md
@@ -14,6 +14,23 @@ unifi-cam-proxy -H {NVR IP} -i {Camera IP} -c /client.pem -t {Adoption token} \
   -s {rtsp stream}
 ```
 
+## Options
+
+```text
+optional arguments:
+  --video-codec {h264,h265}
+                        Select video codec for Protect streams
+```
+
+### H.265 Example
+
+```sh
+unifi-cam-proxy -H {NVR IP} -i {Camera IP} -c /client.pem -t {Adoption token} \
+  rtsp \
+  -s {rtsp stream} \
+  --video-codec h265
+```
+
 ## Hardware Acceleration
 
 ```sg

--- a/docs/docs/configuration/tapo.md
+++ b/docs/docs/configuration/tapo.md
@@ -3,20 +3,34 @@ sidebar_position: 1
 ---
 
 # Tapo
-Unifi-cam-proxy has basic support for Tapo/TPlink cameras, like the C100 or C200 with PTZ. 
 
-To control the PTZ functionality, you have to use the camera image settings in unifi. Adjusting the contrast to anything less than 20 pans the camera a bit to the left, anything over 80 to the right. The brightness setting controls the tilt.
+Unifi-cam-proxy has basic support for Tapo/TPlink cameras, like the C100 or C200 with PTZ.
 
-Make sure to reset the brightness/contrast setting back to somewhere around 50 after adjusting the cameras position, to avoid adjusting the position by accident.
+To control the PTZ functionality, use the camera image settings in UniFi.
+Adjust the contrast below 20 to pan left and above 80 to pan right.
+The brightness setting controls the tilt.
+Reset brightness and contrast to around 50 after adjusting the camera position.
+Otherwise you may change the position by accident.
 
 ## Standard
+
 ```sh
 unifi-cam-proxy -H {NVR IP} -i {Camera IP} -c /client.pem -t {Adoption token} --mac 'AA:BB:CC:00:11:22'\
   tapo \
   --rtsp "rtsp://{camera_username}:{camera_password}@{camera_ip}:554"
 ```
 
+### H.265 Example
+
+```sh
+unifi-cam-proxy -H {NVR IP} -i {Camera IP} -c /client.pem -t {Adoption token} --mac 'AA:BB:CC:00:11:22'\
+  tapo \
+  --rtsp "rtsp://{camera_username}:{camera_password}@{camera_ip}:554" \
+  --video-codec h265
+```
+
 ## PTZ Support
+
 ```sh
 unifi-cam-proxy -H {NVR IP} -i {Camera IP} -c /client.pem -t {Adoption token} --mac 'AA:BB:CC:00:11:22'\
   tapo \


### PR DESCRIPTION
## Summary
- document new `--video-codec` option across camera configuration docs
- remove claim that h265 isn't supported for Amcrest
- add example commands to adopt h265 RTSP streams

## Testing
- `pre-commit run --files docs/docs/configuration/amcrest.md docs/docs/configuration/dahua.md docs/docs/configuration/frigate.md docs/docs/configuration/hikvision.md docs/docs/configuration/reolink.md docs/docs/configuration/reolink_nvr.md docs/docs/configuration/rtsp.md docs/docs/configuration/tapo.md`

------
https://chatgpt.com/codex/tasks/task_e_6844a0c5df04832e81bdb6dae27c7209